### PR TITLE
Edited package.json and ts files to match new @angular imports since …

### DIFF
--- a/app/core/logger.ts
+++ b/app/core/logger.ts
@@ -1,4 +1,4 @@
-import {Injectable, Optional} from "angular2/core";
+import {Injectable, Optional} from "@angular/core";
 import {Level} from "./level";
 
 /**

--- a/core.ts
+++ b/core.ts
@@ -1,4 +1,4 @@
-import {provide} from "angular2/core";
+import {provide} from "@angular/core";
 import {Options, Logger} from "./app/core/logger";
 import {Level} from "./app/core/level";
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "tslint": "^3.8.1",
     "typescript": "^1.8.9",
     "typings": "^0.8.1",
-    "uglify-js": "^2.6.2"
+    "uglify-js": "^2.6.2",
+    "rxjs": "5.0.0-beta.6"
   },
   "peerDependencies": {
     "@angular/common": "^2.0.0-rc.0",

--- a/package.json
+++ b/package.json
@@ -70,20 +70,27 @@
   "homepage": "https://github.com/code-chunks/angular2-logger#readme",
   "dependencies": {},
   "devDependencies": {
-    "angular2": "^2.0.0-beta.17",
+    "@angular/common": "^2.0.0-rc.0",
+    "@angular/compiler": "^2.0.0-rc.0",
+    "@angular/core": "^2.0.0-rc.0",
+    "@angular/platform-browser": "^2.0.0-rc.0",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.0",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.35.0",
+    "zone.js": "^0.6.12",
     "reflect-metadata": "0.1.2",
     "rimraf": "^2.5.2",
-    "rxjs": "5.0.0-beta.6",
     "systemjs": "0.19.27",
     "tslint": "^3.8.1",
     "typescript": "^1.8.9",
     "typings": "^0.8.1",
-    "uglify-js": "^2.6.2",
-    "zone.js": "0.6.12"
+    "uglify-js": "^2.6.2"
   },
   "peerDependencies": {
-    "angular2": "^2.0.0-beta.17"
+    "@angular/common": "^2.0.0-rc.0",
+    "@angular/compiler": "^2.0.0-rc.0",
+    "@angular/core": "^2.0.0-rc.0",
+    "@angular/platform-browser": "^2.0.0-rc.0",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,11 +70,11 @@
   "homepage": "https://github.com/code-chunks/angular2-logger#readme",
   "dependencies": {},
   "devDependencies": {
-    "@angular/common": "^2.0.0-rc.0",
-    "@angular/compiler": "^2.0.0-rc.0",
-    "@angular/core": "^2.0.0-rc.0",
-    "@angular/platform-browser": "^2.0.0-rc.0",
-    "@angular/platform-browser-dynamic": "^2.0.0-rc.0",
+    "@angular/common": "^2.0.0-rc.1",
+    "@angular/compiler": "^2.0.0-rc.1",
+    "@angular/core": "^2.0.0-rc.1",
+    "@angular/platform-browser": "^2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.35.0",
     "zone.js": "^0.6.12",
@@ -88,10 +88,10 @@
     "rxjs": "5.0.0-beta.6"
   },
   "peerDependencies": {
-    "@angular/common": "^2.0.0-rc.0",
-    "@angular/compiler": "^2.0.0-rc.0",
-    "@angular/core": "^2.0.0-rc.0",
-    "@angular/platform-browser": "^2.0.0-rc.0",
-    "@angular/platform-browser-dynamic": "^2.0.0-rc.0"
+    "@angular/common": "^2.0.0-rc.1",
+    "@angular/compiler": "^2.0.0-rc.1",
+    "@angular/core": "^2.0.0-rc.1",
+    "@angular/platform-browser": "^2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.1"
   }
 }


### PR DESCRIPTION
Updated dependencies to avoid conflicts with angular-2.0.0-rc0 applications.
Demos are not working but since you're using code.angularjs.org files, you'll have to wait for them to publish 2.0.0-rc0 to fix them, that's why I didn't do it.