### PR TITLE
improve package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is a work in progress and is not ready for production, use with care, the A
 
 3. Setup the Provider.
 
-        import {Logger} from "angular2-logger/core";
+        import {Logger} from "angular2-logger";
 
         bootstrap( App, [ Logger ]);
 
@@ -63,7 +63,7 @@ In order to see all of the messages you just need to change the logger message h
     
 - Or using one of the predefined configuration providers:
 
-        import {Logger} from "angular2-logger/core";
+        import {Logger} from "angular2-logger";
        
         bootstrap( App, [ LOG_LOGGER_PROVIDERS ]);
 
@@ -85,7 +85,7 @@ If you want the logger to keep this setting changed, store it in the localStorag
 
 If the Providers included don't meet your needs you can configure the default logger configuration by Providing custom properties:
 
-    import { Logger, Options, Level } from "angular2-logger/core";
+    import { Logger, Options, Level } from "angular2-logger";
 
     bootstrap(AppComponent,[
         //<Options> casting is optional, it'll help you with type checking if using an IDE.
@@ -138,7 +138,7 @@ You can also override the default configuration options by extending the Options
 
 Class names like `Options` and `Level` might be too common, if you get a conflict you can rename them like this:
 
-    import { Logger, Options as LoggerOptions, Level as LoggerLevel } from "angular2-logger/core";
+    import { Logger, Options as LoggerOptions, Level as LoggerLevel } from "angular2-logger";
 
     bootstrap(AppComponent,[
         provide( LoggerOptions,{ useValue: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "angular2-logger",
   "version": "0.3.0",
   "description": "A Log4j inspired Logger for Angular 2.",
-  "main": "logger.js",
+  "main": "core.js",
+  "typings": "core.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/code-chunks/angular2-logger"


### PR DESCRIPTION
Improve `package.json` to have a proper `main` and `typings` attribute.

Setting the `main` attribute in `package.json` to `core.js` enables client code to write `import {Logger} from "angular2-logger";` instead of `import {Logger} from "angular2-logger/core";`. Angular2 folks do the same.

Setting the `typings` attribute in `package.json` to `core.d.ts` let's the TypeScript compiler use `core.d.ts` when compiling `import {Logger} from "angular2-logger";`. That's what's needed to avoid compiling whole angular2-logger sources. Angular2 folks do the same. They set the `typings` attribute in `package.json`.