### PR TITLE
Bare-Butt CLI Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-logger",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "A Log4j inspired Logger for Angular 2.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Simplest fix possible for the angular-cli issue #65. However, this is a breaking change that requires the api to be imported from `angular2-logger` instead of `angular2-logger/core`.

All it does is point es6 compatible tools at the `dist/es6/core.js` entry point as if it was an `index.js` in the root folder, and let's ts find `core.d.ts` as if it were `index.d.ts`.

Note: _GitHub should give you the option to squash this into one commit. If it doesn't, let me know and I'll do it._
