### PR TITLE
Adding fixes for typescript >= 2.0.0

### DIFF
--- a/app/core/logger.ts
+++ b/app/core/logger.ts
@@ -59,7 +59,8 @@ export class Logger {
 
     }
 
-    private _loadLevel = (): Level => localStorage.getItem( this._storeAs );
+    private _loadLevel = (): Level => Level[localStorage.getItem( this._storeAs ) as string];
+
     private _storeLevel(level: Level) { localStorage[ this._storeAs ] = level; }
 
     error(message?: any, ...optionalParams: any[]) {


### PR DESCRIPTION
Hi,

This change fixes build issues when using TypeScript >= 2.0.0. Basically, TS compiler does not allow conversion any -> enum anymore.