### PR TITLE
Emit declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,6 @@
     "@angular/platform-browser": "2.0.0-rc.5",
     "@angular/platform-browser-dynamic": "2.0.0-rc.5"
   },
-  "main": "core.js"
+  "main": "dist/es5/core.js",
+  "typings": "dist/es5/core.d.ts"
 }

--- a/tsconfig-es5.json
+++ b/tsconfig-es5.json
@@ -8,13 +8,14 @@
         "module": "commonjs",
         "moduleResolution": "node",
 
-        "outDir": ".",
+        "outDir": "./dist/es5",
 
         "rootDir": ".",
         "sourceMap": true,
         "inlineSources": true,
 //        "lib": ["es6", "dom"],
-        "target": "es5"
+        "target": "es5",
+        "declaration": true
     },
     "files": [
         "core.ts",

--- a/tsconfig-es5.json
+++ b/tsconfig-es5.json
@@ -13,7 +13,6 @@
         "rootDir": ".",
         "sourceMap": true,
         "inlineSources": true,
-//        "lib": ["es6", "dom"],
         "target": "es5",
         "declaration": true
     },

--- a/tsconfig-es6.json
+++ b/tsconfig-es6.json
@@ -7,7 +7,8 @@
     "outDir": "./dist/es6",
     "rootDir": ".",
     "sourceMap": true,
-    "target": "es6"
+    "target": "es6",
+    "declaration": true
   },
   "files": [
     "core.ts"


### PR DESCRIPTION
Hi @langley-agm,

This is second attempt to help resolve issue with build tools like Webpack going crazy when referencing this package (#39 and #65). My previous PR #70 did not in fact solve problem that Webpack should not compile files that are already included in dist folder. Here comes my solution:
1. Let's put ES5 node-compliant files into dist/es5 folder
2. Allow TS compiler to emit declarations both for ES5 and ES6 formats
3. Let's make ES5 output default since any bundler is going to like this moduie format. That way, you can reference logger by just typing:
`import { Logger } from 'angular2-logger';`
no matter if you write in ES6 or TS.

Of course, referencing by `import { Logger } from 'angular2-logger/core';` will still works for users that used it before.